### PR TITLE
fix: get real body content-type of the body fixes #1

### DIFF
--- a/src/Transport/Office365MailTransport.php
+++ b/src/Transport/Office365MailTransport.php
@@ -51,7 +51,7 @@ class Office365MailTransport extends Transport
                     'toRecipients' => $this->getTo($message),
                     'subject' => $message->getSubject(),
                     'body' => [
-                        'contentType' => $message->getContentType() == "text/html" ? 'html' : 'text',
+                        'contentType' => $message->getBodyContentType() == "text/html" ? 'html' : 'text',
                         'content' => $message->getBody()
                     ]
                 ]


### PR DESCRIPTION
When the content-type is `multipart/alternative` then the Mail-Content has mixed content (for example `text/html´ and `text/plain`. So we need to retrieve the contentType of the body.

The content-type `multipart/alternative` is used by default on [Laravel-Notifications](https://laravel.com/docs/master/notifications)