### PR TITLE
feat: added possibility to send large attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,77 @@
-# Laravel Microsoft Graph Mail driver
 
+#  Laravel Microsoft Graph Mail driver
 
-Mail driver for Laravel to send emails using Microsoft Graph without user authetication.
+  
+  
+
+Mail driver for Laravel to send emails using Microsoft Graph without user authentication and SMTP. Only specify the E-Mail-Address in the FROM-Header of the E-Mail and this Office 365 Package will send the E-Mail trough the Microsoft Graph-Api and put the sent E-Mail in the sender's Mailbox sent folder.
+
+**Key features:**
+
+ - Send E-Mails with the Microsoft Graph-Api instead of the SMTP driver
+ - Automatically puts the E-Mail in the Sent folder of the user in the From-Header
+ - One Application per Organization
+ - Supports multiple Domains
+ - Supports large file attachments
+ - Faster and Error-less than the Office-365 SMTP
 
 To use this package you have to register your application [here](https://go.microsoft.com/fwlink/?linkid=2083908). More informations [here](https://docs.microsoft.com/en-us/graph/auth-register-app-v2).
 
-## Install the Package
+  
+
+##  Install the Package
+
 You can install the package with Composer, either run `composer require motze92/office365-mail`, or edit your `composer.json` file:
+
 ```
 {
-    "require": {
-        "motze92/office365-mail": "^1.0"
-    }
+  "require": {
+    "motze92/office365-mail": "^1.0"
+  }
 }
 ```
 
+  
+
 To publish the config file use this command:
 
+  
+
 ```php
-
-php artisan vendor:publish --tag=office365mail
-
+php  artisan  vendor:publish  --tag=office365mail
 ```
 
-## Configure
+  
 
-To obtain needed config values use this [instructions](https://docs.microsoft.com/en-us/graph/auth-v2-service).
+##  Configure
 
-.env
+  
+
+To obtain needed config values use this [instructions](https://docs.microsoft.com/en-us/graph/auth-v2-service):
+
+  - Open the [Azure Active Directory-Portal](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview)) with your Office365 Admin-User
+  - Open the Section Manage > [App-Registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
+  - Create a new App
+  - Within the App under `Manage` >  `API-Permissions` add the `Mail.ReadWrite` permission (Microsoft Graph > Application Permissions > Mail > Mail.ReadWrite)
+  - After saving the permission apply the Admin-Permission for your organization
+  - In the Section Manage > Certificates and Secrets create a new Client Secret with Expiration = never, this you need later for the `.env` - Variable  `OFFICE365MAIL_CLIENT_SECRET`
+
+The `Mail.ReadWrite` Permission is needed when sending large attachments (>4MB).
+  
+#### .env - File
 
 ```
 MAIL_DRIVER=office365mail
-
 OFFICE365MAIL_CLIENT_ID=YOUR-MS-GRAPH-CLIENT-ID
 OFFICE365MAIL_TENANT=YOUR-MS-GRAPH-TENANT-ID
 OFFICE365MAIL_CLIENT_SECRET=YOUR-MS-GRAPH-CLIENT-SECRET
-
 ```
 
-## Copyright and license
+## Credits
+  
+[Moritz Mair](https://clea.solutions/), [Matthias Radmüller](https://www.radmueller.net)
+
+##  Copyright and license
+
 
 Copyright (c) Moritz Mair. All Rights Reserved. Licensed under the MIT [license](LICENSE).

--- a/src/Transport/Office365MailTransport.php
+++ b/src/Transport/Office365MailTransport.php
@@ -5,6 +5,7 @@ namespace Office365Mail\Transport;
 use Illuminate\Mail\Transport\Transport;
 use Swift_Mime_SimpleMessage;
 use Microsoft\Graph\Graph;
+use Microsoft\Graph\Model\UploadSession;
 
 class Office365MailTransport extends Transport
 {
@@ -23,7 +24,89 @@ class Office365MailTransport extends Transport
 
         $graph->setAccessToken($this->getAccessToken());
 
-        $graph->createRequest("POST", "/users/".key($message->getFrom())."/sendmail")->attachBody($this->getBody($message))->execute();
+        $attachmentCount = 0;
+        $attachmentSizeMb = 0;
+        foreach($message->getChildren() as $attachment) {
+            if($attachment instanceof \Swift_Attachment) {
+                $attachmentCount++;
+                $content = $attachment->getBody();
+                $fileSize = strlen($content);
+                $size = $fileSize / 1048576; //byte -> mb
+                $attachmentSizeMb += $size;
+            }
+        }
+
+
+        //special treatment if the message has too large attachments
+        if ($attachmentCount > 0 && $attachmentSizeMb >= 4) {
+            $graphMessage = $graph->createRequest("POST", "/users/".key($message->getFrom())."/messages")
+                ->attachBody($this->getBody($message))
+                ->setReturnType(\Microsoft\Graph\Model\Message::class)
+                ->execute();
+
+            foreach($message->getChildren() as $attachment) {
+                if($attachment instanceof \Swift_Attachment) {
+                    $fileName = $attachment->getHeaders()->get('Content-Disposition')->getParameter('filename');
+                    $content = $attachment->getBody();
+                    $fileSize = strlen($content);
+                    $size = $fileSize / 1048576; //byte -> mb
+                    $attachmentMessage = [
+                        'AttachmentItem' => [
+                            'attachmentType' => 'file',
+                            'name' => $fileName,
+                            'size' => strlen($content)
+                        ]
+                    ];
+
+                    //upload the files in chunks of 4mb....
+                    $uploadSession = $graph->createRequest("POST", "/users/".key($message->getFrom())."/messages/".$graphMessage->getId()."/attachments/createUploadSession")
+                        ->attachBody($attachmentMessage)
+                        ->setReturnType(UploadSession::class)
+                        ->execute();
+
+                    $fragSize =  1024 * 1024 * 4; //4mb at once...
+                    $numFragments = ceil($fileSize / $fragSize);
+                    $contentChunked = str_split($content, $fragSize);
+                    $bytesRemaining = $fileSize;
+                    $i = 0;
+                    while ($i < $numFragments) {
+                        $chunkSize = $numBytes = $fragSize;
+                        $start = $i * $fragSize;
+                        $end = $i * $fragSize + $chunkSize - 1;
+                        if ($bytesRemaining < $chunkSize) {
+                            $chunkSize = $numBytes = $bytesRemaining;
+                            $end = $fileSize - 1;
+                        }
+                        $data = $contentChunked[$i];
+                        $content_range = "bytes " . $start . "-" . $end . "/" . $fileSize;
+                        $headers = [
+                            "Content-Length"=> $numBytes,
+                            "Content-Range"=> $content_range
+                        ];
+                        $client = new \GuzzleHttp\Client();
+                        $tmp = $client->put($uploadSession->getUploadUrl(), [
+                            'headers'         => $headers,
+                            'body'            => $data,
+                            'allow_redirects' => false,
+                            'timeout'         => 1000
+                        ]);
+                        $result = $tmp->getBody().'';
+                        $result = json_decode($result); //if body == empty, then the file was successfully uploaded
+                        $bytesRemaining = $bytesRemaining - $chunkSize;
+                        $i++;
+                    }
+                }
+            }
+
+            //definetly send the message
+            $graph->createRequest("POST", "/users/".key($message->getFrom())."/messages/".$graphMessage->getId()."/send")->execute();
+        } else {
+            $graphMessage = $graph->createRequest("POST", "/users/".key($message->getFrom())."/sendmail")
+                ->attachBody($this->getBody($message, true))
+                ->setReturnType(\Microsoft\Graph\Model\Message::class)
+                ->execute();
+        }
+
 
         $this->sendPerformed($message);
 
@@ -34,43 +117,44 @@ class Office365MailTransport extends Transport
      * Get body for the message.
      *
      * @param \Swift_Mime_SimpleMessage $message
+     * @param bool $withAttachments
      * @return array
      */
 
-    protected function getBody(Swift_Mime_SimpleMessage $message)
+    protected function getBody(Swift_Mime_SimpleMessage $message, $withAttachments = false)
     {
         $messageData = [
-            'message' =>
-                [
-                    'from' => [
-                        'emailAddress' => [
-                            'address' => key($message->getFrom()),
-                            'name' => current($message->getFrom())
-                        ]
-                    ],
-                    'toRecipients' => $this->getTo($message),
-                    'subject' => $message->getSubject(),
-                    'body' => [
-                        'contentType' => $message->getBodyContentType() == "text/html" ? 'html' : 'text',
-                        'content' => $message->getBody()
-                    ]
+            'from' => [
+                'emailAddress' => [
+                    'address' => key($message->getFrom()),
+                    'name' => current($message->getFrom())
                 ]
+            ],
+            'toRecipients' => $this->getTo($message),
+            'subject' => $message->getSubject(),
+            'body' => [
+                'contentType' => $message->getBodyContentType() == "text/html" ? 'html' : 'text',
+                'content' => $message->getBody()
+            ]
         ];
 
-        //add attachments if any
-        $attachments = [];
-        foreach($message->getChildren() as $attachment) {
-            if($attachment instanceof \Swift_Attachment) {
-                $attachments[] = [
-                    "@odata.type" => "#microsoft.graph.fileAttachment",
-                    "name" => $attachment->getHeaders()->get('Content-Disposition')->getParameter('filename'),
-                    "contentType" => $attachment->getBodyContentType(),
-                    "contentBytes" => base64_encode($attachment->getBody())
-                ];
+        if ($withAttachments) {
+            $messageData = ['message' => $messageData];
+            //add attachments if any
+            $attachments = [];
+            foreach($message->getChildren() as $attachment) {
+                if($attachment instanceof \Swift_Attachment) {
+                    $attachments[] = [
+                        "@odata.type" => "#microsoft.graph.fileAttachment",
+                        "name" => $attachment->getHeaders()->get('Content-Disposition')->getParameter('filename'),
+                        "contentType" => $attachment->getBodyContentType(),
+                        "contentBytes" => base64_encode($attachment->getBody())
+                    ];
+                }
             }
-        }
-        if(count($attachments)>0) {
-            $messageData['message']['attachments'] = $attachments;
+            if(count($attachments)>0) {
+                $messageData['message']['attachments'] = $attachments;
+            }
         }
         return $messageData;
     }
@@ -127,4 +211,5 @@ class Office365MailTransport extends Transport
 
         return $token->access_token;
     }
+
 }


### PR DESCRIPTION
Added the possibility to send attachments larger than 4MB

Attention: when upgrading the package to the new version the Permission `Mail.ReadWrite` is needed, before the `Mail.Send` - Permission was sufficient.