### PR TITLE
fix: call parent constructor in Office365MailTransport class

### DIFF
--- a/src/Transport/Office365MailTransport.php
+++ b/src/Transport/Office365MailTransport.php
@@ -12,6 +12,7 @@ class Office365MailTransport extends Transport
 
     public function __construct()
     {
+        parent::__construct();
     }
 
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11294736/175439757-756108f8-cf6b-4540-aac1-43db76c64bff.png)

The parent class has a constructor and the Office365MailTransport class does not call parent construct, so the class are break the application.