### PR TITLE
fix constructor of Office365MailTransport class

### DIFF
--- a/src/Transport/Office365MailTransport.php
+++ b/src/Transport/Office365MailTransport.php
@@ -16,6 +16,7 @@ class Office365MailTransport extends AbstractTransport
 
     public function __construct()
     {
+        parent::__construct();
     }
 
     protected function doSend(SentMessage $message): void


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11294736/175441453-52b223ca-7655-41c8-af72-feeabc40df80.png)

Office365MailTransport does not call parent constructor